### PR TITLE
Update current.html for jdigiclock loading issue

### DIFF
--- a/core/template/dashboard/current.html
+++ b/core/template/dashboard/current.html
@@ -9,9 +9,18 @@
 			<div id="digital_container">
 				<div id="clock">
 					<script type="text/javascript">
-						$(document).ready(function () {
-							$('#digiclock#id#').jdigiclock();
-						});
+			                        function waitReady() {
+			                            /*console.log("waiReady...");*/
+			                            if (typeof $('#digiclock#id#').jdigiclock != 'function') {
+			                                /*console.log("again...");*/
+			                                setTimeout(waitReady, 100);
+			                            } else {
+			                                /*console.log("Ok stop !");*/
+			                                $('#digiclock#id#').jdigiclock();
+			                            }
+			                            /*console.log("End waitReady.");*/
+			                        }
+			                        waitReady();
 					</script>
 				</div>
 				<div id="weather"


### PR DESCRIPTION
Il arrive que l’appel à jdigiclock ne passe pas car son code contenu dans jquery.jdigiclock.js n’est pas encore chargé !
Ce problème ne concerne que le javascript et le chargement de la page, il dépend donc entièrement des capacités du navigateur client et pas du tout des performances de Jeedom côté serveur.

Solution alternative, à base de setTimeout mais auto-adaptative: Le principe est de vérifier l’existance de la fonction toute les 100 ms jusquà ce qu’elle soit chargée