### PR TITLE
Attente du chargement javascript avant d'initialiser l'horloge

### DIFF
--- a/core/template/dashboard/current.html
+++ b/core/template/dashboard/current.html
@@ -9,9 +9,18 @@
 			<div id="digital_container">
 				<div id="clock">
 					<script type="text/javascript">
-						$(document).ready(function () {
-							$('#digiclock#id#').jdigiclock();
-						});
+			                        function waitReady() {
+			                            console.log("waiting...");
+			                            if (typeof $('#digiclock#id#').jdigiclock != 'function') {
+			                                console.log("again !");
+			                                setTimeout(waitReady, 100);
+			                            } else {
+			                                console.log("Ok stop !");
+			                                $('#digiclock#id#').jdigiclock();
+			                            }
+			                            console.log("fin waitReady...");
+			                        }
+			                        waitReady();
 					</script>
 				</div>
 				<div id="weather"

--- a/core/template/dashboard/sansmeteo.html
+++ b/core/template/dashboard/sansmeteo.html
@@ -9,9 +9,18 @@
 		<div id="digital_container">
 			<div id="clock">
 				<script type="text/javascript">
-					$(document).ready(function () {
-						$('#digiclock#id#').jdigiclock();
-					});
+				    function waitReady() {
+						console.log("waiting...");
+						if (typeof $('#digiclock#id#').jdigiclock != 'function') {
+						    console.log("again !");
+						    setTimeout(waitReady, 100);
+						} else {
+						    console.log("Ok stop !");
+						    $('#digiclock#id#').jdigiclock();
+						}
+						console.log("fin waitReady...");
+				    }
+				    waitReady();
 				</script>
 			</div>
 		</div>


### PR DESCRIPTION
Il arrive que l’appel à jdigiclock ne passe pas car son code contenu dans jquery.jdigiclock.js n’est pas encore chargé !
Ce problème ne concerne que le javascript et le chargement de la page, il dépend donc entièrement des capacités du navigateur client et pas du tout des performances de Jeedom côté serveur.

Parmi les pistes proposées, l’augmentation du délai du setTimeout n’est finalement pas retenu car cela dépend du client et le délai « en dur » ne conviens pas toujours. J’ai aussi lu quelque part d’utiliser la fonction JQuery ready() , mais l’idée est de se passer de JQuery.

J’ai donc mis en place une solution alternative, à base de setTimeout mais auto-adaptative: Le principe est de vérifier l’existance de la fonction toute les 100 ms jusquà ce qu’elle soit chargée
Et là ça fonctionne à tous les coups ^^